### PR TITLE
[ci] fail if ROADMAP_TODO.md drifts

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -21,3 +21,5 @@ jobs:
           ruff check .
           black --check .
           bandit -r .
+      - name: Roadmap drift check
+        run: python scripts/check_roadmap_sync.py

--- a/configs/ROADMAP_TODO.md
+++ b/configs/ROADMAP_TODO.md
@@ -36,13 +36,13 @@ Legend
 <!-- TASK:FS10 status=done -->
 - [x] **FS10 – `run_github.sh`** — script to start GitHub MCP (uses `GITHUB_PERSONAL_ACCESS_TOKEN`) on port 8788.
 
-<!-- TASK:FS11 status=pending -->
+<!-- TASK:FS11 status=done -->
 - [x] **FS11 – Optional MCP docs** — new `docs/optional_mcp.md` listing extra servers & env vars.
 
 <!-- TASK:FS12 status=done -->
 - [x] **FS12 – Minimal ADK agent** — instantiate `DevAgent` with LiteLLM (model `openai/codex-mini-latest`).
 
-<!-- TASK:FS13 status=pending -->
+<!-- TASK:FS13 status=done -->
 - [x] **FS13 – Agent docstring** — explain extension points & tool wiring in `dev_agent.py`.
 
 <!-- TASK:FS14 status=done -->
@@ -54,8 +54,8 @@ Legend
 <!-- TASK:FS15 status=done -->
 - [x] **FS15 – Roadmap parser** — code that lists `status=pending` tasks from this file. _(done 2025-05-20)_
 
-<!-- TASK:FS16 status=pending -->
-- [-] **FS16 – Status updater** — helper to flip `status=in_progress/done` in place.
+<!-- TASK:FS16 status=done -->
+- [x] **FS16 – Status updater** — helper to flip `status=in_progress/done` in place.
 
 <!-- TASK:FS17 status=pending -->
 - [ ] **FS17 – Filesystem tool** — add ADK tool pointing at `http://localhost:8787`.

--- a/scripts/check_roadmap_sync.py
+++ b/scripts/check_roadmap_sync.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Verify ROADMAP_TODO.md comment and checkbox status match."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+# Regex patterns reused from status_updater
+TASK_RE = re.compile(r"<!--\s*TASK:(FS\d+)\s+status=([a-z_]+)\s*-->")
+BULLET_RE = re.compile(r"^- \[([xX\- ])\]")
+
+STATUS_FROM_CHECKBOX = {
+    " ": "pending",
+    "-": "in_progress",
+    "x": "done",
+    "X": "done",
+}
+
+
+def check_sync(path: Path) -> list[str]:
+    """Return a list of mismatch errors for the given roadmap."""
+    errors: list[str] = []
+    lines = path.read_text().splitlines()
+    for i, line in enumerate(lines):
+        match = TASK_RE.search(line)
+        if not match:
+            continue
+        task_id, status = match.groups()
+        if i + 1 >= len(lines):
+            errors.append(f"{task_id}: missing checkbox line")
+            continue
+        bullet_line = lines[i + 1].strip()
+        bullet_match = BULLET_RE.match(bullet_line)
+        if not bullet_match:
+            errors.append(f"{task_id}: malformed checkbox line")
+            continue
+        cb_char = bullet_match.group(1)
+        bullet_status = STATUS_FROM_CHECKBOX.get(cb_char)
+        if bullet_status != status:
+            errors.append(
+                f"{task_id}: comment status '{status}' mismatch checkbox '{cb_char}'"
+            )
+        if status in {"in_progress", "done"} and cb_char == " ":
+            errors.append(f"{task_id}: checkbox unchecked for status '{status}'")
+    return errors
+
+
+def main(argv: list[str] | None = None) -> None:
+    path = Path("configs/ROADMAP_TODO.md")
+    errors = check_sync(path)
+    if errors:
+        for err in errors:
+            print(err, file=sys.stderr)
+        raise SystemExit(1)
+    raise SystemExit(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Checklist
- [ ] Branch name starts with codex/
- [ ] Ruff / Black / Bandit exit 0
- [ ] `pytest -q` (once tests exist) exits 0
- [ ] Updated ROADMAP_TODO.md: tick completed task
- [ ] Docs updated if behaviour changed